### PR TITLE
Adiciona label automaticamente nas issues

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,12 @@
+name: Labeling new issue
+on:
+  issues:
+    types: ['opened']
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Renato66/auto-label@v2.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          labels-not-allowed: '["Stale","Pendente de informações","Falta de informações"]'


### PR DESCRIPTION
Com base nas labels existentes no repositório e em palavras chaves na descrição da issue/vaga, adiciona as labels a issue automaticamente.